### PR TITLE
build latest avogadrolib and avogadroapp version

### DIFF
--- a/flatpak/org.openchemistry.Avogadro2.yaml
+++ b/flatpak/org.openchemistry.Avogadro2.yaml
@@ -268,8 +268,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/OpenChemistry/avogadrolibs
-        tag: '1.93.1'
-        commit: 4f1b21de000046c04a39829063c6416fbd70922b
         # Patch from upstream
       - type: patch
         path: fix_find_spglib.patch
@@ -293,7 +291,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/OpenChemistry/avogadroapp
-        tag: '1.93.0'
-        commit: 59c4dbd09821440df02b71fb963c4bae8e0fb6d0
       - type: file
         path: org.openchemistry.Avogadro2.metainfo.xml


### PR DESCRIPTION
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
